### PR TITLE
feat: add requestExamples property to GenerateWorkflowOptions type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -11,7 +11,8 @@ export declare type GenerateWorkflowOptions = {
     examples: boolean,
     schema: boolean
   },
-  contentType: string
+  contentType: string,
+  requestExamples: string
 }
 
 export declare function generateWorkflow(file: any, options: GenerateWorkflowOptions): Promise<object>


### PR DESCRIPTION
This property is used to specify the path to the `contract.examples.yml` file which is used to generate the workflow with a step for each http status code

resolve #2